### PR TITLE
accept and pass props to slides

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "arrowParens": "avoid",
+  "jsxSingleQuote": true,
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "es5"
+}

--- a/src/SlidingForm.js
+++ b/src/SlidingForm.js
@@ -5,7 +5,7 @@ import {
   createElement,
   createRef,
   useMemo,
-} from "react";
+} from 'react'
 import {
   Button,
   Box,
@@ -14,8 +14,8 @@ import {
   StepLabel,
   Step,
   Collapse,
-} from "@mui/material";
-import { ChevronLeftRounded } from "@mui/icons-material";
+} from '@mui/material'
+import { ChevronLeftRounded } from '@mui/icons-material'
 
 const SlidingForm = ({
   slideItems,
@@ -25,32 +25,30 @@ const SlidingForm = ({
   onSlideChange,
   ...props
 }) => {
-  const [currentSlide, setCurrentSlide] = useState(0);
-  const [stepReadyStatus, setStepReadyStatus] = useState({});
-  const [currentData, setCurrentData] = useState({});
-  const [buttonDisabled, setButtonDisabled] = useState(false);
-  const smallScreen = useMediaQuery("(max-width: 1024px)");
-  const refs = { ...slideItems.map(() => createRef()) };
-  const carouselRef = useRef();
-  const lastSlide = currentSlide === slideItems.length - 1;
-  const submitSlide = currentSlide === slideItems.length - 2;
+  const [currentSlide, setCurrentSlide] = useState(0)
+  const [stepReadyStatus, setStepReadyStatus] = useState({})
+  const [currentData, setCurrentData] = useState({})
+  const [buttonDisabled, setButtonDisabled] = useState(false)
+  const smallScreen = useMediaQuery('(max-width: 1024px)')
+  const refs = { ...slideItems.map(() => createRef()) }
+  const carouselRef = useRef()
+  const lastSlide = currentSlide === slideItems.length - 1
+  const submitSlide = currentSlide === slideItems.length - 2
 
-  const steps = slideItems
-    .map((item) => item.label)
-    .filter((i) => i !== undefined);
-  const useStepper = steps.length > 0;
+  const steps = slideItems.map(item => item.label).filter(i => i !== undefined)
+  const useStepper = steps.length > 0
 
   const readySteps = Object.keys(stepReadyStatus).map((item, index) =>
-    stepReadyStatus[index] === true ? item : ""
-  );
+    stepReadyStatus[index] === true ? item : ''
+  )
 
   const itemsWithRefs = useMemo(
     () =>
       slideItems.map((item, index) =>
         createElement(item.slide, {
-          setIsReady: (isReady) =>
+          setIsReady: isReady =>
             isReady !== stepReadyStatus[index] &&
-            setStepReadyStatus((prev) => ({ ...prev, [index]: isReady })),
+            setStepReadyStatus(prev => ({ ...prev, [index]: isReady })),
           refValue: refs[index],
           key: index,
           currentData: currentData,
@@ -58,23 +56,23 @@ const SlidingForm = ({
         })
       ),
     [stepReadyStatus, currentData]
-  );
+  )
 
-  const lastSlideIsVisible = currentSlide === slideItems.length - 1;
+  const lastSlideIsVisible = currentSlide === slideItems.length - 1
 
-  const checkIfButtonDisabled = (step) => !readySteps.includes(step.toString());
+  const checkIfButtonDisabled = step => !readySteps.includes(step.toString())
 
   const handleBack = () => {
-    handleSlideChange(currentSlide - 1);
-  };
+    handleSlideChange(currentSlide - 1)
+  }
 
   const handleForward = () => {
-    handleSlideChange(currentSlide + 1);
-  };
+    handleSlideChange(currentSlide + 1)
+  }
 
   const handleClickForward = () => {
-    !lastSlide && !submitSlide && handleForward();
-    lastSlide && closeAction();
+    !lastSlide && !submitSlide && handleForward()
+    lastSlide && closeAction()
 
     if (submitSlide) {
       submitAction({
@@ -83,45 +81,45 @@ const SlidingForm = ({
             return {
               ...obj,
               ...item.props.refValue.current.getState(),
-            };
+            }
           } else {
-            return obj;
+            return obj
           }
         }, {}),
-      });
+      })
       setTimeout(() => {
-        handleForward();
-      }, 900);
+        handleForward()
+      }, 900)
     }
-  };
+  }
 
   const handleClickBack = () => {
-    currentSlide !== 0 && handleBack();
-    currentSlide === 0 && closeAction();
-  };
+    currentSlide !== 0 && handleBack()
+    currentSlide === 0 && closeAction()
+  }
 
-  const handleSlideChange = (e) => {
-    carouselRef.current && (carouselRef.current.style.overflowX = "auto");
-    setButtonDisabled(false);
+  const handleSlideChange = e => {
+    carouselRef.current && (carouselRef.current.style.overflowX = 'auto')
+    setButtonDisabled(false)
     setTimeout(() => {
-      setCurrentSlide(e);
+      setCurrentSlide(e)
       setTimeout(() => {
-        carouselRef.current && (carouselRef.current.style.overflowX = "hidden");
-      }, 750);
-    }, 250);
+        carouselRef.current && (carouselRef.current.style.overflowX = 'hidden')
+      }, 750)
+    }, 250)
 
     // handle slides that do not call setIsReady, automatically set them to ready
     refs[e] &&
       !refs[e].current &&
-      setStepReadyStatus((prev) => ({ ...prev, [e]: true }));
+      setStepReadyStatus(prev => ({ ...prev, [e]: true }))
 
     setTimeout(
       () =>
         setCurrentData(
           Object.values(refs)
-            .map((item) => {
+            .map(item => {
               if (item) {
-                return item;
+                return item
               }
             })
             .reduce((obj, item) => {
@@ -129,15 +127,15 @@ const SlidingForm = ({
                 return {
                   ...obj,
                   ...item.current.getState(),
-                };
+                }
               } else {
-                return obj;
+                return obj
               }
             }, {})
         ),
       250
-    );
-  };
+    )
+  }
 
   useEffect(() => {
     // on first render, set the height to match the first child
@@ -145,57 +143,57 @@ const SlidingForm = ({
       (carouselRef &&
         carouselRef.current &&
         carouselRef.current.childNodes[0].offsetHeight) ||
-      null;
-    carouselRef.current.style.height = firstSlideHeight + "px" || "0px";
+      null
+    carouselRef.current.style.height = firstSlideHeight + 'px' || '0px'
 
     // fix for iOS bug that breaks scrolling on a div with overflow: hidden;
     firstSlideHeight &&
       Array.from(carouselRef.current.childNodes.values()).map(
-        (node) => (node.style.pointerEvents = "auto")
-      );
-  }, [carouselRef]);
+        node => (node.style.pointerEvents = 'auto')
+      )
+  }, [carouselRef])
 
   useEffect(() => {
     const currentSlideHeight =
       (carouselRef &&
         carouselRef.current &&
         carouselRef.current.childNodes[currentSlide].offsetHeight) ||
-      null;
-    carouselRef.current.style.height = currentSlideHeight + "px" || "0px";
+      null
+    carouselRef.current.style.height = currentSlideHeight + 'px' || '0px'
 
     if (carouselRef.current) {
       carouselRef.current.scrollTo({
         left:
           currentSlide *
           carouselRef.current.childNodes[currentSlide].offsetWidth,
-        behavior: "smooth",
-      });
+        behavior: 'smooth',
+      })
     }
 
-    onSlideChange && onSlideChange(currentSlide);
-  }, [currentSlide]);
+    onSlideChange && onSlideChange(currentSlide)
+  }, [currentSlide])
 
   return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <Box
-        id="carousel-wrapper"
+        id='carousel-wrapper'
         ref={carouselRef}
         sx={{
-          overflow: "hidden",
-          overflowX: "hidden",
-          pointerEvents: "none",
-          display: "flex",
-          transition: "all .5s ease-in-out",
-          "&::-webkit-scrollbar": {
+          overflow: 'hidden',
+          overflowX: 'hidden',
+          pointerEvents: 'none',
+          display: 'flex',
+          transition: 'all .5s ease-in-out',
+          '&::-webkit-scrollbar': {
             display: {
-              xs: "none !important",
-              sm: "none !important",
-              md: "block",
+              xs: 'none !important',
+              sm: 'none !important',
+              md: 'block',
             },
           },
         }}
       >
-        {itemsWithRefs.map((item) => item)}
+        {itemsWithRefs.map(item => item)}
       </Box>
 
       <Box sx={styles.paperChin}>
@@ -204,9 +202,9 @@ const SlidingForm = ({
             <Stepper
               alternativeLabel={smallScreen}
               activeStep={currentSlide}
-              style={{ width: "100%" }}
+              style={{ width: '100%' }}
             >
-              {steps.map((label) => (
+              {steps.map(label => (
                 <Step key={label}>
                   <StepLabel sx={styles.stepLabel}>{label}</StepLabel>
                 </Step>
@@ -217,11 +215,11 @@ const SlidingForm = ({
         <Box
           sx={[
             {
-              justifyContent: "space-between",
-              display: "flex",
+              justifyContent: 'space-between',
+              display: 'flex',
             },
             useStepper && {
-              mt: lastSlideIsVisible ? "0rem" : "1rem",
+              mt: lastSlideIsVisible ? '0rem' : '1rem',
             },
           ]}
         >
@@ -230,14 +228,14 @@ const SlidingForm = ({
               disableElevation
               disableRipple
               onClick={() => {
-                setButtonDisabled(true);
-                handleClickBack();
+                setButtonDisabled(true)
+                handleClickBack()
               }}
-              variant="text"
+              variant='text'
               sx={[styles.textButton]}
               disabled={buttonDisabled}
             >
-              <ChevronLeftRounded sx={{ mr: ".5rem" }} />
+              <ChevronLeftRounded sx={{ mr: '.5rem' }} />
               Back
             </Button>
           </Collapse>
@@ -245,19 +243,19 @@ const SlidingForm = ({
             disableElevation
             disabled={checkIfButtonDisabled(currentSlide) || buttonDisabled}
             onClick={() => {
-              setButtonDisabled(true);
-              handleClickForward();
+              setButtonDisabled(true)
+              handleClickForward()
             }}
             disableRipple
-            variant="contained"
+            variant='contained'
             sx={[styles.filledButton]}
           >
-            {currentSlide === slideItems.length - 1 ? "Got it" : "Next"}
+            {currentSlide === slideItems.length - 1 ? 'Got it' : 'Next'}
           </Button>
         </Box>
       </Box>
     </Box>
-  );
-};
+  )
+}
 
-export default SlidingForm;
+export default SlidingForm

--- a/src/SlidingForm.js
+++ b/src/SlidingForm.js
@@ -4,8 +4,8 @@ import {
   useRef,
   createElement,
   createRef,
-  useMemo
-} from 'react'
+  useMemo,
+} from "react";
 import {
   Button,
   Box,
@@ -13,64 +13,68 @@ import {
   Stepper,
   StepLabel,
   Step,
-  Collapse
-} from '@mui/material'
-import { ChevronLeftRounded } from '@mui/icons-material'
+  Collapse,
+} from "@mui/material";
+import { ChevronLeftRounded } from "@mui/icons-material";
 
 const SlidingForm = ({
   slideItems,
   closeAction,
   submitAction,
   styles,
-  onSlideChange
+  onSlideChange,
+  ...props
 }) => {
-  const [currentSlide, setCurrentSlide] = useState(0)
-  const [stepReadyStatus, setStepReadyStatus] = useState({})
-  const [currentData, setCurrentData] = useState({})
-  const [buttonDisabled, setButtonDisabled] = useState(false)
-  const smallScreen = useMediaQuery('(max-width: 1024px)')
-  const refs = { ...slideItems.map(() => createRef()) }
-  const carouselRef = useRef()
-  const lastSlide = currentSlide === slideItems.length - 1
-  const submitSlide = currentSlide === slideItems.length - 2
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [stepReadyStatus, setStepReadyStatus] = useState({});
+  const [currentData, setCurrentData] = useState({});
+  const [buttonDisabled, setButtonDisabled] = useState(false);
+  const smallScreen = useMediaQuery("(max-width: 1024px)");
+  const refs = { ...slideItems.map(() => createRef()) };
+  const carouselRef = useRef();
+  const lastSlide = currentSlide === slideItems.length - 1;
+  const submitSlide = currentSlide === slideItems.length - 2;
 
-  const steps = slideItems.map(item => item.label).filter(i => i !== undefined)
-  const useStepper = steps.length > 0
+  const steps = slideItems
+    .map((item) => item.label)
+    .filter((i) => i !== undefined);
+  const useStepper = steps.length > 0;
 
   const readySteps = Object.keys(stepReadyStatus).map((item, index) =>
-    stepReadyStatus[index] === true ? item : ''
-  )
+    stepReadyStatus[index] === true ? item : ""
+  );
 
   const itemsWithRefs = useMemo(
     () =>
       slideItems.map((item, index) =>
         createElement(item.slide, {
-          setIsReady: isReady =>
+          setIsReady: (isReady) =>
             isReady !== stepReadyStatus[index] &&
-            setStepReadyStatus(prev => ({ ...prev, [index]: isReady })),
+            setStepReadyStatus((prev) => ({ ...prev, [index]: isReady })),
           refValue: refs[index],
           key: index,
-          currentData: currentData
+          currentData: currentData,
+          ...props,
         })
       ),
     [stepReadyStatus, currentData]
-  )
+  );
 
-  const lastSlideIsVisible = currentSlide === slideItems.length - 1
+  const lastSlideIsVisible = currentSlide === slideItems.length - 1;
 
-  const checkIfButtonDisabled = step => !readySteps.includes(step.toString())
+  const checkIfButtonDisabled = (step) => !readySteps.includes(step.toString());
 
   const handleBack = () => {
-    handleSlideChange(currentSlide - 1)
-  }
+    handleSlideChange(currentSlide - 1);
+  };
 
   const handleForward = () => {
-    handleSlideChange(currentSlide + 1)
-  }
+    handleSlideChange(currentSlide + 1);
+  };
 
   const handleClickForward = () => {
-    !lastSlide && !submitSlide && handleForward()
-    lastSlide && closeAction()
+    !lastSlide && !submitSlide && handleForward();
+    lastSlide && closeAction();
 
     if (submitSlide) {
       submitAction({
@@ -78,62 +82,62 @@ const SlidingForm = ({
           if (item.props.refValue.current) {
             return {
               ...obj,
-              ...item.props.refValue.current.getState()
-            }
+              ...item.props.refValue.current.getState(),
+            };
           } else {
-            return obj
+            return obj;
           }
-        }, {})
-      })
+        }, {}),
+      });
       setTimeout(() => {
-        handleForward()
-      }, 900)
+        handleForward();
+      }, 900);
     }
-  }
+  };
 
   const handleClickBack = () => {
-    currentSlide !== 0 && handleBack()
-    currentSlide === 0 && closeAction()
-  }
+    currentSlide !== 0 && handleBack();
+    currentSlide === 0 && closeAction();
+  };
 
-  const handleSlideChange = e => {
-    carouselRef.current && (carouselRef.current.style.overflowX = 'auto')
-    setButtonDisabled(false)
+  const handleSlideChange = (e) => {
+    carouselRef.current && (carouselRef.current.style.overflowX = "auto");
+    setButtonDisabled(false);
     setTimeout(() => {
-      setCurrentSlide(e)
+      setCurrentSlide(e);
       setTimeout(() => {
-        carouselRef.current && (carouselRef.current.style.overflowX = 'hidden')
-      }, 750)
-    }, 250)
+        carouselRef.current && (carouselRef.current.style.overflowX = "hidden");
+      }, 750);
+    }, 250);
 
     // handle slides that do not call setIsReady, automatically set them to ready
     refs[e] &&
       !refs[e].current &&
-      setStepReadyStatus(prev => ({ ...prev, [e]: true }))
+      setStepReadyStatus((prev) => ({ ...prev, [e]: true }));
 
     setTimeout(
       () =>
         setCurrentData(
           Object.values(refs)
-            .map(item => {
+            .map((item) => {
               if (item) {
-                return item
+                return item;
               }
             })
             .reduce((obj, item) => {
               if (item.current) {
                 return {
                   ...obj,
-                  ...item.current.getState()
-                }
+                  ...item.current.getState(),
+                };
               } else {
-                return obj
+                return obj;
               }
             }, {})
         ),
       250
-    )
-  }
+    );
+  };
 
   useEffect(() => {
     // on first render, set the height to match the first child
@@ -141,57 +145,57 @@ const SlidingForm = ({
       (carouselRef &&
         carouselRef.current &&
         carouselRef.current.childNodes[0].offsetHeight) ||
-      null
-    carouselRef.current.style.height = firstSlideHeight + 'px' || '0px'
+      null;
+    carouselRef.current.style.height = firstSlideHeight + "px" || "0px";
 
     // fix for iOS bug that breaks scrolling on a div with overflow: hidden;
     firstSlideHeight &&
       Array.from(carouselRef.current.childNodes.values()).map(
-        node => (node.style.pointerEvents = 'auto')
-      )
-  }, [carouselRef])
+        (node) => (node.style.pointerEvents = "auto")
+      );
+  }, [carouselRef]);
 
   useEffect(() => {
     const currentSlideHeight =
       (carouselRef &&
         carouselRef.current &&
         carouselRef.current.childNodes[currentSlide].offsetHeight) ||
-      null
-    carouselRef.current.style.height = currentSlideHeight + 'px' || '0px'
+      null;
+    carouselRef.current.style.height = currentSlideHeight + "px" || "0px";
 
     if (carouselRef.current) {
       carouselRef.current.scrollTo({
         left:
           currentSlide *
           carouselRef.current.childNodes[currentSlide].offsetWidth,
-        behavior: 'smooth'
-      })
+        behavior: "smooth",
+      });
     }
 
-    onSlideChange && onSlideChange(currentSlide)
-  }, [currentSlide])
+    onSlideChange && onSlideChange(currentSlide);
+  }, [currentSlide]);
 
   return (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       <Box
-        id='carousel-wrapper'
+        id="carousel-wrapper"
         ref={carouselRef}
         sx={{
-          overflow: 'hidden',
-          overflowX: 'hidden',
-          pointerEvents: 'none',
-          display: 'flex',
-          transition: 'all .5s ease-in-out',
-          '&::-webkit-scrollbar': {
+          overflow: "hidden",
+          overflowX: "hidden",
+          pointerEvents: "none",
+          display: "flex",
+          transition: "all .5s ease-in-out",
+          "&::-webkit-scrollbar": {
             display: {
-              xs: 'none !important',
-              sm: 'none !important',
-              md: 'block'
-            }
-          }
+              xs: "none !important",
+              sm: "none !important",
+              md: "block",
+            },
+          },
         }}
       >
-        {itemsWithRefs.map(item => item)}
+        {itemsWithRefs.map((item) => item)}
       </Box>
 
       <Box sx={styles.paperChin}>
@@ -200,9 +204,9 @@ const SlidingForm = ({
             <Stepper
               alternativeLabel={smallScreen}
               activeStep={currentSlide}
-              style={{ width: '100%' }}
+              style={{ width: "100%" }}
             >
-              {steps.map(label => (
+              {steps.map((label) => (
                 <Step key={label}>
                   <StepLabel sx={styles.stepLabel}>{label}</StepLabel>
                 </Step>
@@ -213,12 +217,12 @@ const SlidingForm = ({
         <Box
           sx={[
             {
-              justifyContent: 'space-between',
-              display: 'flex'
+              justifyContent: "space-between",
+              display: "flex",
             },
             useStepper && {
-              mt: lastSlideIsVisible ? '0rem' : '1rem'
-            }
+              mt: lastSlideIsVisible ? "0rem" : "1rem",
+            },
           ]}
         >
           <Collapse in={!lastSlideIsVisible}>
@@ -226,14 +230,14 @@ const SlidingForm = ({
               disableElevation
               disableRipple
               onClick={() => {
-                setButtonDisabled(true)
-                handleClickBack()
+                setButtonDisabled(true);
+                handleClickBack();
               }}
-              variant='text'
+              variant="text"
               sx={[styles.textButton]}
               disabled={buttonDisabled}
             >
-              <ChevronLeftRounded sx={{ mr: '.5rem' }} />
+              <ChevronLeftRounded sx={{ mr: ".5rem" }} />
               Back
             </Button>
           </Collapse>
@@ -241,19 +245,19 @@ const SlidingForm = ({
             disableElevation
             disabled={checkIfButtonDisabled(currentSlide) || buttonDisabled}
             onClick={() => {
-              setButtonDisabled(true)
-              handleClickForward()
+              setButtonDisabled(true);
+              handleClickForward();
             }}
             disableRipple
-            variant='contained'
+            variant="contained"
             sx={[styles.filledButton]}
           >
-            {currentSlide === slideItems.length - 1 ? 'Got it' : 'Next'}
+            {currentSlide === slideItems.length - 1 ? "Got it" : "Next"}
           </Button>
         </Box>
       </Box>
     </Box>
-  )
-}
+  );
+};
 
-export default SlidingForm
+export default SlidingForm;


### PR DESCRIPTION
Use the `rest` operator to grab any additional props passed to the Sliding Form component, then use `spread` operator to pass to slide components. (See lines 26 & 55)

Also added `prettierrc.json` because VSCode went ham on it. 🥲 